### PR TITLE
Added basic node inspector support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,15 @@ Lists loaded middleware (express only) without running the app.
 
 Lists app settings (express only) without running the app.
 
+Debugging Options
+-----------------
+
+There are 3 debugging options:
+
+* `start --debug`  This option works the same as running `node --debug`.
+* `start --debug-brk`  This option works the same as running `node --debug-brk`.
+* `start --node-inspector`  This option uses [node-inspector](https://github.com/node-inspector/node-inspector).
+
 Port Binding
 ------------
 

--- a/bin/startup-start
+++ b/bin/startup-start
@@ -24,6 +24,7 @@ program
   .option('-d, --dev', 'run in development mode')
   .option('--debug', 'run the debugger')
   .option('--debug-brk', 'run the debugger with a break on start')
+  .option('--node-inspector', 'run node-debug to enable debugging in the browser')
   .option('--use-strict', 'use strict mode')
   // .option('-s, --shutdown <shutdown>', 'server shutdown timeout')
   // .option('-t, --timeout <timeout>', 'worker restart timeout')
@@ -107,6 +108,25 @@ if (program.debug || program.debugBrk) {
   if (strict) args.unshift(strict);
 
   var proc = spawn('node', args, { stdio: 'inherit', customFds: [0, 1, 2] });
+
+  return proc.on('close', function(code){
+    process.exit(code);
+  });
+}
+
+/**
+ * Run in debug mode using node-inspector
+ */
+if (program.nodeInspector) {
+  // setup the arguments
+  var args = [
+    runner,
+    path
+  ];
+
+  if (strict) args.unshift(strict);
+
+  var proc = spawn('node-debug', args, { stdio: 'inherit', customFds: [0, 1, 2] });
 
   return proc.on('close', function(code){
     process.exit(code);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "startup",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Node.js HTTP app runner",
   "scripts": {
     "test": "./node_modules/.bin/mocha"


### PR DESCRIPTION
# Problem space:
- We don't have a way to debug Frontier apps without using an IDE with remote debugging capabilities.
 
# Changes:
- [ ] Added support for node-inspector by adding the --node-inspector option.
- [ ] Updated README.md.
 
# Should:
- [ ] Open a web page that works similarly to the Chrome DevTools and allows debugging for Frontier apps when the option --node-inspector is used in the Procfile.

# Example Procfile:
`web: ./node_modules/.bin/startup start --node-inspector`