### PR TITLE
Fix issue with server not restarting in dev mode

### DIFF
--- a/bin/startup-start
+++ b/bin/startup-start
@@ -145,7 +145,7 @@ if (program.nodeInspector) {
 if (program.dev || process.env.NODE_ENV === 'development') {
   utils.log('info', 'auto-reload enabled');
 
-  var cmd = process.env.STARTUP_DEV_SCRIPT || require.resolve('node-dev/bin/node-dev');
+  var cmd = process.env.STARTUP_DEV_SCRIPT || require.resolve('nodemon/bin/nodemon');
 
   var args = [
     runner,

--- a/bin/startup-start
+++ b/bin/startup-start
@@ -70,7 +70,7 @@ var path = utils.resolve(program.app || program.path);
  * resolve the runner path
  */
 
-var runner = resolve(__dirname, '../lib/runner');
+var runner = resolve(__dirname, '../lib/runner.js');
 
 /**
  * make sure the app exists

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cli-table": "~0.2.0",
     "commander": "~1.1.1",
     "envs": "~0.1.3",
-    "node-dev": "~3.1.2",
+    "nodemon": "^1.14.12",
     "uuid": "^3.0.0",
     "win-fork": "~1.1.1"
   },


### PR DESCRIPTION
I still don't know exactly what causes the issue but I know this fixes it.

Startup uses node-dev internally to detect changes in development mode when restart is enabled. There's something going wrong in the interplay between node-dev and frontier. startup (and node-dev) behave as expected with fresh express apps. And nodemon properly detects changes in frontier.

The good news is the issue isn't being caused by a hanging processes, timeouts, or intervals in frontier; snow appears to be doing everything right.